### PR TITLE
Update  Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ import (
   "log"
 
   "github.com/boltdb/bolt"
-  stow "gopkg.in/djherbis/stow.v2"
+   "gopkg.in/djherbis/stow.v2"
 )
 
 func main() {


### PR DESCRIPTION
The package name is `stow` so `stow` is what is going to be imported. There is no need for the named import.