### PR TITLE
Fix return errors from boltdb Get/Delete requests

### DIFF
--- a/store.go
+++ b/store.go
@@ -98,8 +98,7 @@ func (s *Store) put(key []byte, b interface{}) (err error) {
 		if err != nil {
 			return err
 		}
-		objects.Put(key, data)
-		return nil
+		return objects.Put(key, data)
 	})
 }
 
@@ -132,8 +131,7 @@ func (s *Store) pull(key []byte, b interface{}) error {
 		}
 
 		buf.Write(data)
-		objects.Delete(key)
-		return nil
+		return objects.Delete(key)
 	})
 
 	if err != nil {


### PR DESCRIPTION
The return error of get and pull requests agains a boltdb instance was
assumed to never return an error and ignored those. This was fixed by
returning the error from the corresponding boltdb Get/Delete call.